### PR TITLE
Fixes erroneous mention of email address instead of phone number

### DIFF
--- a/documentation/commands/phone/index.md
+++ b/documentation/commands/phone/index.md
@@ -15,7 +15,7 @@ ppl phone - List, show or change phone numbers
     ppl phone <contact>
     ppl phone <contact> <phone-number>
     ppl phone <contact> <phone-number>
-        -d, --delete         delete email address
+        -d, --delete         delete phone number
         -t, --type <type>    set the number's type
         -p, --preferred      mark as preferred
         -P, --not-preferred  mark as not preferred


### PR DESCRIPTION
In the documentation for using the `phone` command it said that `delete` would delete the email address instead of the phone number.

I fixed it so that it says `delete phone number`.